### PR TITLE
fix: Exclude member-linked volunteers from volunteers directory

### DIFF
--- a/src/app/api/volunteers/route.ts
+++ b/src/app/api/volunteers/route.ts
@@ -12,7 +12,12 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // Only return standalone volunteers (not linked to members)
+  // Members assigned to events as volunteers are tracked separately
   const volunteers = await prisma.volunteer.findMany({
+    where: {
+      userId: null, // Exclude member-linked volunteers
+    },
     include: {
       events: {
         select: {


### PR DESCRIPTION
## Problem
When adding a member to an event as a volunteer, the system created a `Volunteer` record linked to that user (via `userId`). These member-linked volunteers were then appearing on the main Volunteers page, cluttering the directory with members who are tracked separately.

## Solution
Added `where: { userId: null }` filter to the volunteers GET API to only return standalone volunteers — those not linked to member accounts.

Member assignments to events are still tracked via the `EventVolunteer` join table and appear correctly on event pages.