### PR TITLE
fix: exclude volunteers from members API regardless of role

### DIFF
--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -16,12 +16,10 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const callerRole = session.user.globalRole as GlobalRole;
-
   const users = await prisma.user.findMany({
     where: {
-      // Only Super Admins can see volunteer-role users in the members list
-      ...(callerRole !== "SUPER_ADMIN" ? { globalRole: { not: "VOLUNTEER" } } : {}),
+      // Members API should never include volunteer-role users
+      globalRole: { not: "VOLUNTEER" },
     },
     select: {
       id: true,


### PR DESCRIPTION
**Changes:**
- Remove conditional logic that allowed Super Admins to see volunteers in members list
- Members and volunteers should be managed separately via their respective APIs
- Ensures cleaner separation of concerns between member and volunteer management

**Why:**
The members API should focus exclusively on users with member-related roles (MEMBER, ADMIN, SUPER_ADMIN). Volunteers have their own dedicated API endpoint and should not appear in the members list, regardless of who is viewing it.