### PR TITLE
Add venue request CC controls and improve email template

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -59,6 +59,7 @@ async function main() {
     { key: "meetup_description", value: "" },
     { key: "meetup_website", value: "" },
     { key: "meetup_past_event_link", value: "" },
+    { key: "venue_request_cc", value: "" },
     { key: "volunteer_promotion_threshold", value: "5" },
     { key: "min_volunteer_tasks", value: "7" },
     { key: "min_event_duration", value: "4" }

--- a/src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
+++ b/src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
@@ -6,6 +6,8 @@ import { sendEmail } from "@/lib/email";
 import { logAudit } from "@/lib/audit";
 import type { GlobalRole } from "@/generated/prisma/enums";
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 function escapeHtml(input: string): string {
   return input
     .replace(/&/g, "&amp;")
@@ -13,6 +15,44 @@ function escapeHtml(input: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+function logoAttachmentFromDataUri(dataUri: string, cid: string) {
+  const match = dataUri.match(/^data:(image\/[a-z+]+);base64,(.+)$/i);
+  if (!match) return null;
+
+  return {
+    filename: `logo.${match[1].split("/")[1].replace("+xml", "")}`,
+    content: Buffer.from(match[2], "base64"),
+    contentType: match[1],
+    cid,
+  };
+}
+
+function parseCcEmails(value: unknown): string[] {
+  if (typeof value === "string") {
+    return Array.from(
+      new Set(
+        value
+          .split(/[,\n]/)
+          .map((email) => email.trim().toLowerCase())
+          .filter(Boolean)
+      )
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(
+        value
+          .filter((entry): entry is string => typeof entry === "string")
+          .map((email) => email.trim().toLowerCase())
+          .filter(Boolean)
+      )
+    );
+  }
+
+  return [];
 }
 
 export async function POST(
@@ -41,10 +81,18 @@ export async function POST(
   const body = await req.json().catch(() => ({}));
   const subject = typeof body.subject === "string" ? body.subject.trim() : "";
   const message = typeof body.message === "string" ? body.message.trim() : "";
+  const ccEmails = parseCcEmails(body.cc);
+  const invalidCc = ccEmails.find((email) => !EMAIL_REGEX.test(email));
 
   if (!subject || !message) {
     return NextResponse.json(
       { error: "subject and message are required" },
+      { status: 400 }
+    );
+  }
+  if (invalidCc) {
+    return NextResponse.json(
+      { error: `Invalid CC email: ${invalidCc}` },
       { status: 400 }
     );
   }
@@ -88,19 +136,36 @@ export async function POST(
     where: { key: "meetup_name" },
     select: { value: true },
   });
+  const logoLightSetting = await prisma.appSetting.findUnique({
+    where: { key: "logo_light" },
+    select: { value: true },
+  });
   const cleanedMeetupName = (meetupNameSetting?.value || "Meetup")
     .replace(/\s*manager\s*$/i, "")
     .trim();
   const fromName = cleanedMeetupName || "Meetup";
 
-  const html = `<div style="font-family:Arial,sans-serif;white-space:pre-wrap;line-height:1.5;">${escapeHtml(message)}</div>`;
+  const logoCid = "venue-request-logo";
+  const logoAttachment = logoLightSetting?.value
+    ? logoAttachmentFromDataUri(logoLightSetting.value, logoCid)
+    : null;
+
+  const html = [
+    `<div style="font-family:Arial,sans-serif;white-space:pre-wrap;line-height:1.5;">${escapeHtml(message)}</div>`,
+    logoAttachment
+      ? `<div style="margin-top:16px;"><img src="cid:${logoCid}" alt="${escapeHtml(fromName)} logo" style="max-height:48px;max-width:220px;display:block;" /></div>`
+      : "",
+  ].join("");
+
   const result = await sendEmail({
     to: link.venuePartner.email,
+    cc: ccEmails.length > 0 ? ccEmails : undefined,
     subject,
     html,
     text: message,
     template: templateKey,
     fromName,
+    attachments: logoAttachment ? [logoAttachment] : undefined,
   });
 
   if (!result.success) {
@@ -119,6 +184,7 @@ export async function POST(
     changes: {
       venueRequestEmail: {
         to: link.venuePartner.email,
+        cc: ccEmails,
         subject,
         status: "SENT",
       },
@@ -128,5 +194,6 @@ export async function POST(
   return NextResponse.json({
     success: true,
     sentTo: link.venuePartner.email,
+    cc: ccEmails,
   });
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -6,7 +6,7 @@ import { logAudit } from "@/lib/audit";
 import type { GlobalRole } from "@/generated/prisma/enums";
 
 // Public settings anyone authenticated can read
-const PUBLIC_KEYS = ["volunteer_promotion_threshold", "meetup_name", "meetup_description", "meetup_website", "meetup_past_event_link", "min_volunteer_tasks", "min_event_duration", "logo_light", "logo_dark"];
+const PUBLIC_KEYS = ["volunteer_promotion_threshold", "meetup_name", "meetup_description", "meetup_website", "meetup_past_event_link", "venue_request_cc", "min_volunteer_tasks", "min_event_duration", "logo_light", "logo_dark"];
 
 // Max size for base64 logo values (~200KB encoded)
 const MAX_LOGO_SIZE = 300_000;
@@ -35,13 +35,6 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  if (!hasMinimumRole(session.user.globalRole as GlobalRole, "SUPER_ADMIN")) {
-    return NextResponse.json(
-      { error: "Forbidden: Super Admin role required" },
-      { status: 403 }
-    );
-  }
-
   const body = await req.json();
   const { key, value } = body;
 
@@ -51,6 +44,14 @@ export async function PATCH(req: NextRequest) {
 
   if (!PUBLIC_KEYS.includes(key)) {
     return NextResponse.json({ error: "Unknown setting key" }, { status: 400 });
+  }
+
+  const minimumRole = "SUPER_ADMIN";
+  if (!hasMinimumRole(session.user.globalRole as GlobalRole, minimumRole)) {
+    return NextResponse.json(
+      { error: `Forbidden: ${minimumRole.replace("_", " ")} role required` },
+      { status: 403 }
+    );
   }
 
   // Validate logo size

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -82,6 +82,19 @@ type EventVolunteerItem = EventDetail["volunteers"][number];
 const INPUT_CLASS =
   "w-full bg-background border border-border rounded-lg px-3.5 py-2.5 text-sm placeholder:text-muted/50 focus:border-accent focus:ring-1 focus:ring-accent/30 outline-none transition-all";
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function splitAndNormalizeEmails(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(/[,\n]/)
+        .map((email) => email.trim().toLowerCase())
+        .filter(Boolean)
+    )
+  );
+}
+
 type PickerTab = "members" | "directory";
 
 function VolunteerPicker({
@@ -1361,7 +1374,14 @@ export default function EventDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { data: session } = useSession();
-  const { meetupName, meetupDescription, meetupWebsite, meetupPastEventLink, minVolunteerTasks } = useAppSettings();
+  const {
+    meetupName,
+    meetupDescription,
+    meetupWebsite,
+    meetupPastEventLink,
+    venueRequestCc,
+    minVolunteerTasks,
+  } = useAppSettings();
   const userRole = session?.user?.globalRole ?? "VIEWER";
   const canEdit = (ROLE_LEVEL[userRole] ?? 0) >= ROLE_LEVEL.EVENT_LEAD;
   const isAdmin = (ROLE_LEVEL[userRole] ?? 0) >= ROLE_LEVEL.ADMIN;
@@ -1440,6 +1460,7 @@ export default function EventDetailPage() {
   } | null>(null);
   const [venueRequestSubject, setVenueRequestSubject] = useState("");
   const [venueRequestBody, setVenueRequestBody] = useState("");
+  const [venueRequestCcList, setVenueRequestCcList] = useState("");
   const [venueRequestSending, setVenueRequestSending] = useState(false);
   const [venueRequestError, setVenueRequestError] = useState<string | null>(null);
   const [venueRequestSuccess, setVenueRequestSuccess] = useState<string | null>(null);
@@ -1554,52 +1575,58 @@ export default function EventDetailPage() {
       return;
     }
 
-    const eventType = event.title.toLowerCase().includes("workshop")
-      ? "Workshop"
-      : event.title.toLowerCase().includes("hackathon")
-        ? "Hackathon"
-        : "Community Meetup";
-
     const requirementLines = [
-      `- Capacity for ${venueLink.venuePartner.capacity ?? 80} attendees`,
-      "- Projector / screen and audio support",
+      `- Capacity for approximately ${venueLink.venuePartner.capacity ?? 80} attendees`,
+      "- Projector/screen and audio support",
       "- Reliable Wi-Fi access",
-      "- Seating arrangement for talks and networking",
+      "- Seating suitable for talks and networking",
+      "- If possible, refreshments for attendees",
     ];
     const emailMeetupName =
       meetupName.replace(/\s*manager\s*$/i, "").trim() || meetupName;
+    const groupDescription = meetupDescription?.trim() || "<Description>";
+    const eventDescription = event.description?.trim() || "";
+    const senderName = session?.user?.name?.trim() || "Event Team";
+    const signaturePrimary = emailMeetupName;
 
     const draft = [
-      `Hi ${venueLink.venuePartner.contactName ?? "Team"},`,
+      `Hi ${venueLink.venuePartner.name} Team,`,
+      "",
+      "Hope you're doing well!",
       "",
       `I'm reaching out on behalf of ${emailMeetupName} to check if your venue can host our upcoming event.`,
       "",
-      "Meetup Group",
-      `${emailMeetupName}`,
-      ...(meetupDescription ? [`- Description: ${meetupDescription}`] : []),
-      ...(meetupWebsite ? [`- Website: ${meetupWebsite}`] : []),
-      ...(meetupPastEventLink ? [`- You guys can check out our past events here: ${meetupPastEventLink}`] : []),
+      `About ${emailMeetupName}`,
+      groupDescription,
       "",
-      "Event Type",
-      `${eventType}`,
+      "You can explore our past events here:",
+      meetupPastEventLink || "<Past events link>",
       "",
+      "More about us:",
+      meetupWebsite || "<Website link>",
       "Event Details",
-      `- Event: ${event.title}`,
-      `- Date: ${formatDateTimeRange(event.date, event.endDate)}`,
-      ...(event.description ? [`- Description: ${event.description}`] : []),
+      "",
+      `Event Name: ${event.title}`,
+      `Description: ${eventDescription}`,
+      `Date: ${formatDateTimeRange(event.date, event.endDate)}`,
       "",
       "Event Requirements",
+      "",
+      "We're looking for:",
       ...requirementLines,
       "",
-      "Please let us know your availability and any hosting terms.",
+      "Could you please let us know about availability and any hosting terms or requirements from your side?",
       "",
-      "Thanks,",
-      `${session?.user?.name ?? "Event Team"}`,
-      `${emailMeetupName}`,
+      "Looking forward to your response.",
+      "",
+      "Warm regards,",
+      senderName,
+      signaturePrimary,
     ].join("\n");
 
     setVenueRequestSubject(`Venue request: ${event.title} by ${emailMeetupName}`);
     setVenueRequestBody(draft);
+    setVenueRequestCcList(venueRequestCc);
     setVenueRequestError(null);
     setVenueRequestSuccess(null);
     setVenueRequestModal({
@@ -1616,6 +1643,13 @@ export default function EventDetailPage() {
       return;
     }
 
+    const ccEmails = splitAndNormalizeEmails(venueRequestCcList);
+    const invalidCc = ccEmails.find((email) => !EMAIL_REGEX.test(email));
+    if (invalidCc) {
+      setVenueRequestError(`Invalid CC email: ${invalidCc}`);
+      return;
+    }
+
     setVenueRequestSending(true);
     setVenueRequestError(null);
     setVenueRequestSuccess(null);
@@ -1626,6 +1660,7 @@ export default function EventDetailPage() {
         body: JSON.stringify({
           subject: venueRequestSubject.trim(),
           message: venueRequestBody.trim(),
+          cc: ccEmails,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -2228,6 +2263,28 @@ export default function EventDetailPage() {
             </div>
 
             <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium mb-1.5">To</label>
+                <input
+                  type="text"
+                  value={venueRequestModal?.venueEmail ?? ""}
+                  readOnly
+                  className={cn(INPUT_CLASS, "bg-muted/20")}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">CC</label>
+                <textarea
+                  value={venueRequestCcList}
+                  onChange={(e) => setVenueRequestCcList(e.target.value)}
+                  rows={2}
+                  placeholder="ops@example.com, lead@example.com"
+                  className={INPUT_CLASS}
+                />
+                <p className="mt-1 text-xs text-muted">
+                  Add one or more CC emails separated by commas or new lines.
+                </p>
+              </div>
               <div>
                 <label className="block text-sm font-medium mb-1.5">Subject</label>
                 <input

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -12,12 +12,28 @@ const INPUT_CLASS =
   "w-full bg-background border border-border rounded-lg px-3.5 py-2.5 text-sm placeholder:text-muted/50 focus:border-accent focus:ring-1 focus:ring-accent/30 outline-none transition-all";
 
 function AppConfigCard() {
-  const { meetupName, setMeetupName, meetupWebsite, meetupPastEventLink, minVolunteerTasks, setMinVolunteerTasks, minEventDuration, setMinEventDuration, logoLight, setLogoLight, logoDark, setLogoDark } = useAppSettings();
+  const {
+    meetupName,
+    setMeetupName,
+    meetupWebsite,
+    meetupPastEventLink,
+    venueRequestCc,
+    setVenueRequestCc,
+    minVolunteerTasks,
+    setMinVolunteerTasks,
+    minEventDuration,
+    setMinEventDuration,
+    logoLight,
+    setLogoLight,
+    logoDark,
+    setLogoDark,
+  } = useAppSettings();
   const [config, setConfig] = useState({
     meetupName: "",
     meetupDescription: "",
     meetupWebsite: "",
     meetupPastEventLink: "",
+    venueRequestCc: "",
     volunteerThreshold: "5",
     minVolunteerTasks: "7", 
     minEventDuration: "4"
@@ -38,6 +54,7 @@ function AppConfigCard() {
       meetupName,
       meetupWebsite,
       meetupPastEventLink,
+      venueRequestCc,
       minVolunteerTasks: String(minVolunteerTasks),
       minEventDuration: String(minEventDuration)
     }));
@@ -51,13 +68,14 @@ function AppConfigCard() {
           meetupDescription: data.meetup_description ?? "",
           meetupWebsite: data.meetup_website ?? "",
           meetupPastEventLink: data.meetup_past_event_link ?? "",
+          venueRequestCc: data.venue_request_cc ?? "",
         }));
         if (data.volunteer_promotion_threshold) {
           setConfig(prev => ({ ...prev, volunteerThreshold: data.volunteer_promotion_threshold }));
         }
       })
       .catch(() => {});
-  }, [meetupName, meetupWebsite, meetupPastEventLink, minVolunteerTasks, minEventDuration]);
+  }, [meetupName, meetupWebsite, meetupPastEventLink, venueRequestCc, minVolunteerTasks, minEventDuration]);
 
   useEffect(() => {
     setLightPreview(logoLight);
@@ -76,7 +94,7 @@ function AppConfigCard() {
         return;
       }
       value = trimmed;
-    } else if (key === "meetupDescription" || key === "meetupWebsite" || key === "meetupPastEventLink") {
+    } else if (key === "meetupDescription" || key === "meetupWebsite" || key === "meetupPastEventLink" || key === "venueRequestCc") {
       value = value.trim();
     } else if (['volunteerThreshold', 'minVolunteerTasks', 'minEventDuration'].includes(key)) {
       const num = parseInt(value, 10);
@@ -100,6 +118,7 @@ function AppConfigCard() {
         meetupDescription: "meetup_description",
         meetupWebsite: "meetup_website",
         meetupPastEventLink: "meetup_past_event_link",
+        venueRequestCc: "venue_request_cc",
         volunteerThreshold: 'volunteer_promotion_threshold',
         minVolunteerTasks: 'min_volunteer_tasks',
         minEventDuration: 'min_event_duration'
@@ -471,6 +490,49 @@ function AppConfigCard() {
             </Button>
           </div>
           {errors.meetupPastEventLink && <p className="mt-2 text-sm text-status-blocked">{errors.meetupPastEventLink}</p>}
+        </div>
+
+        {/* Default Venue Request CC */}
+        <div>
+          <div className="flex items-end gap-3">
+            <div className="flex-1 max-w-[640px]">
+              <label className="block text-sm font-medium mb-1.5">
+                Default Venue Request CC Emails
+              </label>
+              <input
+                type="text"
+                value={config.venueRequestCc}
+                onChange={(e) => {
+                  setConfig(prev => ({ ...prev, venueRequestCc: e.target.value }));
+                  setSaved(prev => ({ ...prev, venueRequestCc: false }));
+                }}
+                placeholder="ops@example.com, lead@example.com"
+                className={INPUT_CLASS}
+              />
+              <p className="mt-1 text-xs text-muted">
+                Optional. Comma-separated emails automatically added in venue request drafts.
+              </p>
+            </div>
+            <Button
+              size="md"
+              onClick={() => handleSave("venueRequestCc", config.venueRequestCc, setVenueRequestCc)}
+              disabled={saving.venueRequestCc}
+              className={cn(saved.venueRequestCc && "bg-status-done/15 text-status-done border-status-done/20")}
+            >
+              {saved.venueRequestCc ? (
+                <>
+                  <Check className="h-4 w-4" /> Saved
+                </>
+              ) : saving.venueRequestCc ? (
+                "Saving…"
+              ) : (
+                <>
+                  <Save className="h-4 w-4" /> Save
+                </>
+              )}
+            </Button>
+          </div>
+          {errors.venueRequestCc && <p className="mt-2 text-sm text-status-blocked">{errors.venueRequestCc}</p>}
         </div>
 
         {/* Min Event Duration */}

--- a/src/app/settings/permissions/page.tsx
+++ b/src/app/settings/permissions/page.tsx
@@ -273,7 +273,19 @@ const PERMISSIONS: PermissionRow[] = [
       ADMIN: "none",
       SUPER_ADMIN: "full",
     },
-    note: "Meetup name, volunteer thresholds, minimum tasks",
+    note: "Meetup name, volunteer thresholds, minimum tasks, and logos (Super Admin only)",
+  },
+  {
+    feature: "Venue Request CC Settings",
+    icon: Mail,
+    actions: {
+      VIEWER: "none",
+      VOLUNTEER: "none",
+      EVENT_LEAD: "none",
+      ADMIN: "limited",
+      SUPER_ADMIN: "full",
+    },
+    note: "Default CC in Settings is Super Admin only. Admins can still add/edit CC recipients while composing a venue request email.",
   },
 ];
 
@@ -556,7 +568,7 @@ export default function PermissionsPage() {
           <div className="flex items-start gap-2">
             <span className="text-accent font-bold mt-0.5">2.</span>
             <p>
-              <strong className="text-foreground">Only Super Admins</strong> can assign the Admin role, delete members, or change app-wide settings.
+              <strong className="text-foreground">Only Super Admins</strong> can assign the Admin role, delete members, or change app-wide settings (including default Venue Request CC settings).
             </p>
           </div>
           <div className="flex items-start gap-2">

--- a/src/lib/app-settings-context.tsx
+++ b/src/lib/app-settings-context.tsx
@@ -8,6 +8,8 @@ interface AppSettingsContextValue {
   meetupDescription: string;
   meetupWebsite: string;
   meetupPastEventLink: string;
+  venueRequestCc: string;
+  setVenueRequestCc: (emails: string) => void;
   minVolunteerTasks: number;
   setMinVolunteerTasks: (n: number) => void;
   minEventDuration: number;
@@ -25,6 +27,8 @@ const AppSettingsContext = createContext<AppSettingsContextValue>({
   meetupDescription: "",
   meetupWebsite: "",
   meetupPastEventLink: "",
+  venueRequestCc: "",
+  setVenueRequestCc: () => {},
   minVolunteerTasks: 7,
   setMinVolunteerTasks: () => {},
   minEventDuration: 4,
@@ -41,6 +45,7 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
   const [meetupDescription, setMeetupDescription] = useState("");
   const [meetupWebsite, setMeetupWebsite] = useState("");
   const [meetupPastEventLink, setMeetupPastEventLink] = useState("");
+  const [venueRequestCc, setVenueRequestCc] = useState("");
   const [minVolunteerTasks, setMinVolunteerTasks] = useState(7);
   const [minEventDuration, setMinEventDuration] = useState(4);
   const [logoLight, setLogoLight] = useState<string | null>(null);
@@ -62,6 +67,9 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
         }
         if ("meetup_past_event_link" in data) {
           setMeetupPastEventLink(data.meetup_past_event_link || "");
+        }
+        if ("venue_request_cc" in data) {
+          setVenueRequestCc(data.venue_request_cc || "");
         }
         if (data.min_volunteer_tasks) {
           const parsed = parseInt(data.min_volunteer_tasks, 10);
@@ -86,6 +94,10 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
     setMinVolunteerTasks(n);
   }, []);
 
+  const updateVenueRequestCc = useCallback((emails: string) => {
+    setVenueRequestCc(emails);
+  }, []);
+
   const updateMinEventDuration = useCallback((hours: number) => {
     setMinEventDuration(hours);
   }, []);
@@ -106,6 +118,8 @@ export function AppSettingsProvider({ children }: { children: ReactNode }) {
         meetupDescription,
         meetupWebsite,
         meetupPastEventLink,
+        venueRequestCc,
+        setVenueRequestCc: updateVenueRequestCc,
         minVolunteerTasks,
         setMinVolunteerTasks: updateMinVolunteerTasks,
         minEventDuration,


### PR DESCRIPTION
## Summary
- add configurable default venue-request CC setting and expose it in app settings context
- support editable CC recipients in venue request composer with validation in UI and API
- embed configured logo as CID at the end of venue request email body
- update venue request draft format to the new structure and signature with logged-in admin name
- update permissions matrix copy for venue request CC behavior

## Testing
- npm run lint -- src/app/api/settings/route.ts src/app/settings/permissions/page.tsx
- npm run lint -- src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
- manual verification of venue request compose flow