### PR TITLE
Add public Code of Conduct page with Super Admin-managed content

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ This app uses NextAuth v5 with Google as the web sign-in provider.
 
 - **Permissions & Access** — read-only reference page showing global roles, permission matrix, event roles, and key rules
 - **Email Workflows** — visual reference for all 11 automated email notifications with trigger conditions, recipients, and subject lines; accessible to all authenticated users at `/settings/permissions/email-workflows`
+- **Public Code of Conduct** — policy page at `/docs/code-of-conduct` with publicly visible content and Super Admin-managed updates from Settings
 
 ### Audit Trail
 
@@ -251,6 +252,7 @@ This app uses NextAuth v5 with Google as the web sign-in provider.
 
 - **Volunteer promotion threshold** — Super Admin-only setting to configure the minimum event contributions before a volunteer can be promoted to member
 - **Group logo upload** — upload light and dark logo variants (PNG, JPEG, SVG, WebP, max 200KB); the light logo is automatically embedded in all email headers via CID attachment
+- **Public Code of Conduct editor** — Super Admin-only save control for HTML policy content displayed on the public Code of Conduct page
 - **Key-value store** — extensible `AppSetting` model for future settings
 - **Logo serving endpoint** — `GET /api/settings/logo?variant=light|dark` serves stored logos as real images with caching headers (public, no auth required)
 - **Audit-logged** — all setting changes are tracked
@@ -267,7 +269,7 @@ This app uses NextAuth v5 with Google as the web sign-in provider.
 | `VOLUNTEER` | Volunteer | 1 | Read assigned events, self-assign tasks, toggle own task status |
 | `EVENT_LEAD` | Member | 2 | Create and manage events, read all events, manage speakers / volunteers / venues |
 | `ADMIN` | Admin | 3 | Full access to all events, manage members (except other admins), audit log |
-| `SUPER_ADMIN` | Super Admin | 4 | Everything + manage admins, app settings, member removal with ownership reassignment |
+| `SUPER_ADMIN` | Super Admin | 4 | Everything + manage admins, app settings, public Code of Conduct publishing, member removal with ownership reassignment |
 
 ### Event Roles (per-event, hierarchy 0 → 3)
 

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -160,6 +160,17 @@
           <article class="feature">
             <span class="feature-icon" aria-hidden="true">
               <svg viewBox="0 0 24 24" class="feature-icon-svg">
+                <path d="M12 3l7 4v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V7l7-4z"></path>
+                <path d="M8 11h8"></path>
+                <path d="M8 15h5"></path>
+              </svg>
+            </span>
+            <h3>Public Code of Conduct</h3>
+            <p>Share a public policy page that organizers can update from app settings with role-based controls.</p>
+          </article>
+          <article class="feature">
+            <span class="feature-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" class="feature-icon-svg">
                 <polyline points="16 18 22 12 16 6"></polyline>
                 <polyline points="8 6 2 12 8 18"></polyline>
               </svg>

--- a/src/app/api/email/test/route.ts
+++ b/src/app/api/email/test/route.ts
@@ -211,20 +211,38 @@ function buildTemplateElement(
           logoUrl,
         }),
       };
-    case "speaker-invitation":
+    case "speaker-invitation": {
+      const eventDate = new Date(Date.now() + 14 * 86400000);
+      const eventEndDate = new Date(eventDate.getTime() + 3 * 3600000);
+      const icsContent = generateICS({
+        title: "Sample Tech Meetup",
+        description: "Speaker invitation test for " + name,
+        startDate: eventDate,
+        endDate: eventEndDate,
+        location: "Innovation Hub, Downtown",
+        url: `${appUrl}/events/sample-123`,
+      });
       return {
         subject: `[Test] Speaker Invitation — ${name}`,
         element: React.createElement(SpeakerInvitationEmail, {
           speakerName: "Dr. Jane Smith",
           eventTitle: "Sample Tech Meetup",
           topic: "The Future of AI in Web Development",
-          date: new Date(Date.now() + 14 * 86400000).toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit" }),
-          endDate: new Date(Date.now() + 14 * 86400000 + 3 * 3600000).toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit" }),
+          date: eventDate.toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit" }),
+          endDate: eventEndDate.toLocaleDateString("en-US", { weekday: "long", year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit" }),
           venue: "Innovation Hub, Downtown",
           appName,
           logoUrl,
         }),
+        attachments: [
+          {
+            filename: "speaker-invitation.ics",
+            content: icsContent,
+            contentType: "text/calendar",
+          },
+        ],
       };
+    }
     case "venue-confirmed":
       return {
         subject: `[Test] Venue Confirmed — ${name}`,

--- a/src/app/api/settings/public/route.ts
+++ b/src/app/api/settings/public/route.ts
@@ -4,9 +4,32 @@ import { prisma } from "@/lib/prisma";
 // Public endpoint - no auth required
 // Returns meetup name and logo for public pages
 export async function GET() {
-  const settings = await prisma.appSetting.findMany({
-    where: { key: { in: ["meetup_name", "meetup_description", "meetup_website", "meetup_past_event_link", "logo_light", "logo_dark"] } },
-  });
+  const [settings, superAdmins] = await Promise.all([
+    prisma.appSetting.findMany({
+      where: {
+        key: {
+          in: [
+            "meetup_name",
+            "meetup_description",
+            "meetup_website",
+            "meetup_past_event_link",
+            "logo_light",
+            "logo_dark",
+            "code_of_conduct_content",
+          ],
+        },
+      },
+    }),
+    prisma.user.findMany({
+      where: {
+        globalRole: "SUPER_ADMIN",
+        deletedAt: null,
+        email: { not: null },
+      },
+      select: { email: true },
+      orderBy: { createdAt: "asc" },
+    }),
+  ]);
 
   const result: Record<string, string> = {};
   for (const s of settings) {
@@ -20,5 +43,7 @@ export async function GET() {
     meetupPastEventLink: result.meetup_past_event_link ?? "",
     logoLight: result.logo_light ?? null,
     logoDark: result.logo_dark ?? null,
+    codeOfConductContent: result.code_of_conduct_content ?? "",
+    superAdminEmails: superAdmins.map((admin) => admin.email).filter((email): email is string => Boolean(email)),
   });
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -6,7 +6,19 @@ import { logAudit } from "@/lib/audit";
 import type { GlobalRole } from "@/generated/prisma/enums";
 
 // Public settings anyone authenticated can read
-const PUBLIC_KEYS = ["volunteer_promotion_threshold", "meetup_name", "meetup_description", "meetup_website", "meetup_past_event_link", "venue_request_cc", "min_volunteer_tasks", "min_event_duration", "logo_light", "logo_dark"];
+const PUBLIC_KEYS = [
+  "volunteer_promotion_threshold",
+  "meetup_name",
+  "meetup_description",
+  "meetup_website",
+  "meetup_past_event_link",
+  "venue_request_cc",
+  "min_volunteer_tasks",
+  "min_event_duration",
+  "logo_light",
+  "logo_dark",
+  "code_of_conduct_content",
+];
 
 // Max size for base64 logo values (~200KB encoded)
 const MAX_LOGO_SIZE = 300_000;

--- a/src/app/docs/code-of-conduct/page.tsx
+++ b/src/app/docs/code-of-conduct/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Zap, Scale, ShieldCheck, Mail } from "lucide-react";
+import { Zap, Scale, ShieldCheck } from "lucide-react";
 
 const DEFAULT_COC_CONTENT = `
 <p>We are committed to a welcoming, safe, and inclusive community experience for everyone.</p>
@@ -35,7 +35,6 @@ export default function CodeOfConductPage() {
   const [logoLight, setLogoLight] = useState<string | null>(null);
   const [logoDark, setLogoDark] = useState<string | null>(null);
   const [codeOfConductContent, setCodeOfConductContent] = useState("");
-  const [superAdminEmails, setSuperAdminEmails] = useState<string[]>([]);
   const [isDark, setIsDark] = useState(() => {
     if (typeof window === "undefined") return true;
     return window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -58,11 +57,6 @@ export default function CodeOfConductPage() {
         if (data.logoDark) setLogoDark(data.logoDark);
         if (typeof data.codeOfConductContent === "string") {
           setCodeOfConductContent(data.codeOfConductContent);
-        }
-        if (Array.isArray(data.superAdminEmails)) {
-          setSuperAdminEmails(
-            data.superAdminEmails.filter((email: unknown): email is string => typeof email === "string" && email.length > 0)
-          );
         }
       })
       .catch(() => {});
@@ -126,34 +120,6 @@ export default function CodeOfConductPage() {
           </div>
         </section>
 
-        <section className="mb-16">
-          <div className="rounded-xl border border-border bg-surface p-6 sm:p-8">
-            <h2 className="text-xl font-semibold font-[family-name:var(--font-display)] mb-3 flex items-center gap-2">
-              <Mail className="h-5 w-5 text-accent" />
-              Contact Team Heads
-            </h2>
-            <p className="text-sm text-muted mb-4">
-              For queries or concerns related to the Code of Conduct, contact our team heads.
-            </p>
-            {superAdminEmails.length > 0 ? (
-              <div className="flex flex-wrap gap-2">
-                {superAdminEmails.map((email) => (
-                  <a
-                    key={email}
-                    href={`mailto:${email}?subject=Code%20of%20Conduct%20Concern`}
-                    className="text-sm px-3 py-1.5 rounded-md border border-border hover:border-accent/40 hover:bg-accent/5 transition-colors"
-                  >
-                    {email}
-                  </a>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted">
-                Contact details are currently unavailable. Please reach out through the event organizers.
-              </p>
-            )}
-          </div>
-        </section>
       </main>
 
       <footer className="relative z-10 border-t border-border py-6 mt-12">

--- a/src/app/docs/code-of-conduct/page.tsx
+++ b/src/app/docs/code-of-conduct/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { Zap, Scale, ShieldCheck, Mail } from "lucide-react";
+
+const DEFAULT_COC_CONTENT = `
+<p>We are committed to a welcoming, safe, and inclusive community experience for everyone.</p>
+<ul>
+  <li>Treat members, volunteers, speakers, and guests with respect.</li>
+  <li>Avoid harassment, intimidation, discrimination, or personal attacks.</li>
+  <li>Do not share private information without consent.</li>
+  <li>Help us maintain a constructive, collaborative atmosphere.</li>
+</ul>
+<p>If you witness or experience a violation, contact an event lead, organizer, or admin as soon as possible.</p>
+<p>Violations may result in warnings, removal from events/channels, temporary suspension, or permanent removal from the community.</p>
+`;
+
+function sanitizeHtmlContent(input: string): string {
+  return input
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, "")
+    .replace(/<iframe[\s\S]*?>[\s\S]*?<\/iframe>/gi, "")
+    .replace(/<object[\s\S]*?>[\s\S]*?<\/object>/gi, "")
+    .replace(/<embed[\s\S]*?>[\s\S]*?<\/embed>/gi, "")
+    .replace(/\son\w+=(["']).*?\1/gi, "")
+    .replace(/\son\w+=([^\s>]+)/gi, "")
+    .replace(/(href|src)\s*=\s*(["'])\s*javascript:[\s\S]*?\2/gi, '$1="#"');
+}
+
+export default function CodeOfConductPage() {
+  const { data: session } = useSession();
+  const [meetupName, setMeetupName] = useState("Event Manager");
+  const [logoLight, setLogoLight] = useState<string | null>(null);
+  const [logoDark, setLogoDark] = useState<string | null>(null);
+  const [codeOfConductContent, setCodeOfConductContent] = useState("");
+  const [superAdminEmails, setSuperAdminEmails] = useState<string[]>([]);
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const handleChange = (e: MediaQueryListEvent) => setIsDark(e.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/settings/public")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.meetupName) setMeetupName(data.meetupName);
+        if (data.logoLight) setLogoLight(data.logoLight);
+        if (data.logoDark) setLogoDark(data.logoDark);
+        if (typeof data.codeOfConductContent === "string") {
+          setCodeOfConductContent(data.codeOfConductContent);
+        }
+        if (Array.isArray(data.superAdminEmails)) {
+          setSuperAdminEmails(
+            data.superAdminEmails.filter((email: unknown): email is string => typeof email === "string" && email.length > 0)
+          );
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  const logo = isDark ? (logoDark || logoLight) : (logoLight || logoDark);
+  const content = (codeOfConductContent || DEFAULT_COC_CONTENT).trim();
+  const safeHtml = sanitizeHtmlContent(content);
+  const isSuperAdmin = session?.user?.globalRole === "SUPER_ADMIN";
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="fixed inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-1/2 -left-1/2 h-full w-full rounded-full bg-accent/5 blur-[120px]" />
+        <div className="absolute -bottom-1/2 -right-1/2 h-full w-full rounded-full bg-emerald-500/5 blur-[120px]" />
+      </div>
+
+      <header className="relative z-10 border-b border-border bg-surface/80 backdrop-blur-sm">
+        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-center">
+          <Link href="/" className="flex items-center gap-3 group">
+            {logo ? (
+              <img src={logo} alt={meetupName} className="h-12 w-auto" />
+            ) : (
+              <div className="h-12 w-12 rounded-lg bg-gradient-to-br from-accent to-amber-600 flex items-center justify-center shrink-0">
+                <Zap className="h-5 w-5 text-accent-fg" />
+              </div>
+            )}
+            <span className="font-semibold font-[family-name:var(--font-display)] text-sm group-hover:text-accent transition-colors">
+              {meetupName}
+            </span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="relative z-10 max-w-4xl mx-auto px-6 py-12">
+        <div className="text-center mb-16">
+          <div className="inline-flex items-center justify-center h-14 w-14 rounded-2xl bg-accent/10 mb-4">
+            <Scale className="h-7 w-7 text-accent" />
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold font-[family-name:var(--font-display)] tracking-tight mb-4">
+            Public Code of Conduct
+          </h1>
+          <p className="text-muted text-lg max-w-2xl mx-auto">
+            Our community is built on trust, respect, and accountability. This
+            code applies to all events, online spaces, and team interactions.
+          </p>
+        </div>
+
+        <section className="mb-16">
+          <div className="rounded-xl border border-border bg-surface p-6 sm:p-8">
+            {isSuperAdmin && (
+              <div className="flex items-center gap-2 mb-5">
+                <ShieldCheck className="h-5 w-5 text-accent" />
+                <p className="text-sm font-medium">This policy is managed in workspace settings.</p>
+              </div>
+            )}
+            <div
+              className="text-sm text-muted leading-relaxed space-y-4 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:text-accent [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-accent [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-accent [&_h4]:font-semibold [&_h4]:text-accent [&_p]:mb-3 [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:mb-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:mb-3 [&_a]:text-accent [&_a]:underline [&_strong]:text-foreground"
+              dangerouslySetInnerHTML={{ __html: safeHtml }}
+            />
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <div className="rounded-xl border border-border bg-surface p-6 sm:p-8">
+            <h2 className="text-xl font-semibold font-[family-name:var(--font-display)] mb-3 flex items-center gap-2">
+              <Mail className="h-5 w-5 text-accent" />
+              Contact Team Heads
+            </h2>
+            <p className="text-sm text-muted mb-4">
+              For queries or concerns related to the Code of Conduct, contact our team heads.
+            </p>
+            {superAdminEmails.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {superAdminEmails.map((email) => (
+                  <a
+                    key={email}
+                    href={`mailto:${email}?subject=Code%20of%20Conduct%20Concern`}
+                    className="text-sm px-3 py-1.5 rounded-md border border-border hover:border-accent/40 hover:bg-accent/5 transition-colors"
+                  >
+                    {email}
+                  </a>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted">
+                Contact details are currently unavailable. Please reach out through the event organizers.
+              </p>
+            )}
+          </div>
+        </section>
+      </main>
+
+      <footer className="relative z-10 border-t border-border py-6 mt-12">
+        <div className="max-w-4xl mx-auto px-6 text-center text-sm text-muted">
+          <p>
+            By participating in {meetupName}, you agree to uphold this Code of
+            Conduct.
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -31,6 +31,7 @@ function AppConfigCard() {
   const [config, setConfig] = useState({
     meetupName: "",
     meetupDescription: "",
+    codeOfConductContent: "",
     meetupWebsite: "",
     meetupPastEventLink: "",
     venueRequestCc: "",
@@ -66,6 +67,7 @@ function AppConfigCard() {
         setConfig(prev => ({
           ...prev,
           meetupDescription: data.meetup_description ?? "",
+          codeOfConductContent: data.code_of_conduct_content ?? "",
           meetupWebsite: data.meetup_website ?? "",
           meetupPastEventLink: data.meetup_past_event_link ?? "",
           venueRequestCc: data.venue_request_cc ?? "",
@@ -94,7 +96,13 @@ function AppConfigCard() {
         return;
       }
       value = trimmed;
-    } else if (key === "meetupDescription" || key === "meetupWebsite" || key === "meetupPastEventLink" || key === "venueRequestCc") {
+    } else if (
+      key === "meetupDescription" ||
+      key === "codeOfConductContent" ||
+      key === "meetupWebsite" ||
+      key === "meetupPastEventLink" ||
+      key === "venueRequestCc"
+    ) {
       value = value.trim();
     } else if (['volunteerThreshold', 'minVolunteerTasks', 'minEventDuration'].includes(key)) {
       const num = parseInt(value, 10);
@@ -116,6 +124,7 @@ function AppConfigCard() {
       const apiKey = {
         meetupName: 'meetup_name',
         meetupDescription: "meetup_description",
+        codeOfConductContent: "code_of_conduct_content",
         meetupWebsite: "meetup_website",
         meetupPastEventLink: "meetup_past_event_link",
         venueRequestCc: "venue_request_cc",
@@ -410,6 +419,52 @@ function AppConfigCard() {
             </div>
           </div>
           {errors.meetupDescription && <p className="mt-2 text-sm text-status-blocked">{errors.meetupDescription}</p>}
+        </div>
+
+        {/* Public Code of Conduct */}
+        <div>
+          <div className="flex flex-col gap-3">
+            <div className="max-w-[720px]">
+              <label className="block text-sm font-medium mb-1.5">
+                Public Code of Conduct
+              </label>
+              <textarea
+                value={config.codeOfConductContent}
+                onChange={(e) => {
+                  setConfig(prev => ({ ...prev, codeOfConductContent: e.target.value }));
+                  setSaved(prev => ({ ...prev, codeOfConductContent: false }));
+                }}
+                placeholder="<h2>Our Code of Conduct</h2><p>Write policy content using HTML tags like h2, p, ul, li, a, strong.</p>"
+                rows={10}
+                className={INPUT_CLASS}
+              />
+              <p className="mt-1 text-xs text-muted flex items-center gap-1.5">
+                <Shield className="h-3.5 w-3.5" />
+                HTML content is shown on <span className="font-mono text-[11px]">/docs/code-of-conduct</span> for public visitors and logged-in users.
+              </p>
+            </div>
+            <div>
+              <Button
+                size="md"
+                onClick={() => handleSave("codeOfConductContent", config.codeOfConductContent)}
+                disabled={saving.codeOfConductContent}
+                className={cn(saved.codeOfConductContent && "bg-status-done/15 text-status-done border-status-done/20")}
+              >
+                {saved.codeOfConductContent ? (
+                  <>
+                    <Check className="h-4 w-4" /> Saved
+                  </>
+                ) : saving.codeOfConductContent ? (
+                  "Saving…"
+                ) : (
+                  <>
+                    <Save className="h-4 w-4" /> Save
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+          {errors.codeOfConductContent && <p className="mt-2 text-sm text-status-blocked">{errors.codeOfConductContent}</p>}
         </div>
 
         {/* Meetup Website */}

--- a/src/app/settings/permissions/page.tsx
+++ b/src/app/settings/permissions/page.tsx
@@ -253,6 +253,30 @@ const PERMISSIONS: PermissionRow[] = [
     },
   },
   {
+    feature: "Public Code of Conduct (View)",
+    icon: ScrollText,
+    actions: {
+      VIEWER: "full",
+      VOLUNTEER: "full",
+      EVENT_LEAD: "full",
+      ADMIN: "full",
+      SUPER_ADMIN: "full",
+    },
+    note: "Accessible at /docs/code-of-conduct for both signed-in users and public visitors",
+  },
+  {
+    feature: "Public Code of Conduct (Edit)",
+    icon: ScrollText,
+    actions: {
+      VIEWER: "none",
+      VOLUNTEER: "none",
+      EVENT_LEAD: "none",
+      ADMIN: "none",
+      SUPER_ADMIN: "full",
+    },
+    note: "Only Super Admin can edit/publish content changes",
+  },
+  {
     feature: "Discord Integration",
     icon: Bot,
     actions: {

--- a/src/components/layout/command-palette.tsx
+++ b/src/components/layout/command-palette.tsx
@@ -14,6 +14,7 @@ import {
   ClipboardCheck,
   Search,
   Building2,
+  FileText,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -33,6 +34,7 @@ const COMMANDS: Command[] = [
   { label: "Speakers", href: "/speakers", icon: Mic2, group: "Navigate", minRole: "EVENT_LEAD" },
   { label: "Venue Partners", href: "/venues", icon: Building2, group: "Navigate", minRole: "EVENT_LEAD" },
   { label: "Volunteers", href: "/volunteers", icon: Users, group: "Navigate", minRole: "EVENT_LEAD" },
+  { label: "Code of Conduct", href: "/docs/code-of-conduct", icon: FileText, group: "Navigate" },
   { label: "SOP Templates", href: "/settings/templates", icon: ClipboardCheck, group: "Navigate", minRole: "EVENT_LEAD" },
   { label: "Settings", href: "/settings", icon: Settings, group: "Navigate", minRole: "ADMIN" },
 ];

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -21,7 +21,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { useAppSettings } from "@/lib/app-settings-context";
 
-type NavItem = { label: string; href: string; icon: LucideIcon; minRole?: string };
+type NavItem = { label: string; href: string; icon: LucideIcon; minRole?: string; public?: boolean };
 
 const ROLE_LEVEL: Record<string, number> = {
   VIEWER: 0,
@@ -44,7 +44,8 @@ const NAV_ITEMS: NavItem[] = [
 ];
 
 const DOCUMENTS_ITEMS: NavItem[] = [
-  { label: "How to Become a Member", href: "/docs/how-to-become-a-member", icon: Users },
+  { label: "How to Become a Member", href: "/docs/how-to-become-a-member", icon: Users, public: true },
+  { label: "Code of Conduct", href: "/docs/code-of-conduct", icon: FileText, public: true },
   { label: "Roles & Permissions", href: "/settings/permissions", icon: Shield },
 ];
 
@@ -157,6 +158,11 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                 >
                   <Icon className={cn("h-4 w-4 shrink-0", active && "text-accent")} />
                   {!collapsed && <span>{item.label}</span>}
+                  {item.public && !collapsed && (
+                    <span className="ml-auto text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded border border-accent/30 bg-accent/10 text-accent">
+                      Public
+                    </span>
+                  )}
                 </Link>
               );
             })}

--- a/src/lib/emails/triggers.ts
+++ b/src/lib/emails/triggers.ts
@@ -538,11 +538,24 @@ export async function sendSpeakerInvitationEmail(
       where: { id: eventSpeakerId },
       include: {
         speaker: { select: { name: true, email: true, topic: true } },
-        event: { select: { title: true, date: true, endDate: true, venue: true } },
+        event: { select: { id: true, title: true, date: true, endDate: true, venue: true } },
       },
     });
 
     if (!link || !link.speaker.email) return;
+
+    const appUrl = getAppUrl();
+    const eventUrl = `${appUrl}/events/${link.event.id}`;
+    const icsContent = generateICS({
+      title: link.event.title,
+      description: link.speaker.topic
+        ? `Speaker invitation for ${link.event.title}. Topic: ${link.speaker.topic}`
+        : `Speaker invitation for ${link.event.title}`,
+      startDate: link.event.date,
+      endDate: link.event.endDate,
+      location: link.event.venue ?? undefined,
+      url: eventUrl,
+    });
 
     const branding = await getEmailBranding();
 
@@ -560,7 +573,15 @@ export async function sendSpeakerInvitationEmail(
         appName: branding.appName,
         logoUrl: branding.logoUrl,
       }),
-      brandingOptions(branding)
+      brandingOptions(branding, {
+        attachments: [
+          {
+            filename: "speaker-invitation.ics",
+            content: icsContent,
+            contentType: "text/calendar",
+          },
+        ],
+      })
     );
   } catch (err) {
     console.error("[Email] Speaker invitation trigger error:", err);


### PR DESCRIPTION
## Summary
- add a new /docs/code-of-conduct page with public + authenticated shell behavior
- make COC content editable from Settings (Super Admin only) via app settings
- render COC content as sanitized HTML and auto-style headings with accent color
- add team head contact emails on the COC page
- add Public badge in sidebar for public docs routes

## Routing behavior
- unauthenticated users can access public docs without dashboard shell
- authenticated users view docs inside dashboard shell and left navigation

## Notes
- includes sidebar and command palette navigation updates for the new COC page