### PR TITLE
feat: move venue request contacts to editable body and use dark logo

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
       createdBy: { select: { id: true, name: true, image: true, email: true } },
       members: {
         include: {
-          user: { select: { id: true, name: true, image: true, email: true } },
+          user: { select: { id: true, name: true, image: true, email: true, phone: true } },
         },
       },
       speakers: {

--- a/src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
+++ b/src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
@@ -132,17 +132,9 @@ export async function POST(
     );
   }
 
-  const [meetupNameSetting, logoLightSetting, eventLeads, adminUsers] = await Promise.all([
+  const [meetupNameSetting, logoDarkSetting] = await Promise.all([
     prisma.appSetting.findUnique({ where: { key: "meetup_name" }, select: { value: true } }),
-    prisma.appSetting.findUnique({ where: { key: "logo_light" }, select: { value: true } }),
-    prisma.eventMember.findMany({
-      where: { eventId, eventRole: { in: ["LEAD", "ORGANIZER"] } },
-      include: { user: { select: { id: true, name: true, phone: true, email: true } } },
-    }),
-    prisma.user.findMany({
-      where: { globalRole: "ADMIN", deletedAt: null },
-      select: { id: true, name: true, phone: true, email: true },
-    }),
+    prisma.appSetting.findUnique({ where: { key: "logo_dark" }, select: { value: true } }),
   ]);
 
   const cleanedMeetupName = (meetupNameSetting?.value || "Meetup")
@@ -150,38 +142,13 @@ export async function POST(
     .trim();
   const fromName = cleanedMeetupName || "Meetup";
 
-  // Build deduplicated contact list (event leads first, then admins)
-  const contactMap = new Map<string, { name: string | null; phone: string | null; role: string }>();
-  for (const m of eventLeads) {
-    contactMap.set(m.user.id, { name: m.user.name, phone: m.user.phone, role: "Event Lead" });
-  }
-  for (const u of adminUsers) {
-    if (!contactMap.has(u.id)) {
-      contactMap.set(u.id, { name: u.name, phone: u.phone, role: "Admin" });
-    }
-  }
-  const contacts = Array.from(contactMap.values()).filter((c) => c.phone);
-
   const logoCid = "venue-request-logo";
-  const logoAttachment = logoLightSetting?.value
-    ? logoAttachmentFromDataUri(logoLightSetting.value, logoCid)
+  const logoAttachment = logoDarkSetting?.value
+    ? logoAttachmentFromDataUri(logoDarkSetting.value, logoCid)
     : null;
-
-  const contactsHtml = contacts.length > 0
-    ? `<div style="margin-top:24px;padding-top:16px;border-top:1px solid #e5e7eb;font-family:Arial,sans-serif;">` +
-      `<p style="margin:0 0 10px 0;font-size:14px;color:#374151;">If you have any doubts, please feel free to contact us:</p>` +
-      contacts.map((c) =>
-        `<p style="margin:0 0 4px 0;font-size:13px;color:#4b5563;">` +
-        `<strong>${escapeHtml(c.name ?? "Team Member")}</strong>` +
-        ` &mdash; ${escapeHtml(c.phone!)}` +
-        `</p>`
-      ).join("") +
-      `</div>`
-    : "";
 
   const html = [
     `<div style="font-family:Arial,sans-serif;white-space:pre-wrap;line-height:1.5;">${escapeHtml(message)}</div>`,
-    contactsHtml,
     logoAttachment
       ? `<div style="margin-top:16px;"><img src="cid:${logoCid}" alt="${escapeHtml(fromName)} logo" style="max-height:48px;max-width:220px;display:block;" /></div>`
       : "",

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -31,7 +31,7 @@ interface EventDetail {
   pageLink: string | null;
   status: string;
   createdBy: { id: string; name: string | null; image: string | null };
-  members: { eventRole: string; user: { id: string; name: string | null; image: string | null } }[];
+  members: { eventRole: string; user: { id: string; name: string | null; image: string | null; phone: string | null } }[];
   speakers: {
     id: string;
     status: string;
@@ -1703,7 +1703,7 @@ export default function EventDetailPage() {
     if (res.ok) fetchEvent();
   };
 
-  const openVenueRequestComposer = (venueLink: VenuePartnerItem) => {
+  const openVenueRequestComposer = async (venueLink: VenuePartnerItem) => {
     if (!event) return;
     if (!venueLink.venuePartner.email) {
       alert("This venue partner does not have an email address.");
@@ -1728,6 +1728,31 @@ export default function EventDetailPage() {
     const senderName = session?.user?.name?.trim() || "Event Team";
     const signaturePrimary = emailMeetupName;
 
+    // Fetch admin contacts with phone numbers
+    const contactLines: string[] = [];
+    try {
+      const membersRes = await fetch("/api/members");
+      if (membersRes.ok) {
+        const allMembers: { globalRole: string; name: string | null; phone: string | null }[] = await membersRes.json();
+        const adminContacts = allMembers.filter(
+          (m) => m.globalRole === "ADMIN" && m.phone
+        );
+        // Event leads from this event with phone
+        const leadContacts = event.members
+          .filter((m) => ["LEAD", "ORGANIZER"].includes(m.eventRole) && m.user.phone)
+          .map((m) => ({ name: m.user.name, phone: m.user.phone }));
+        // Deduplicate by name
+        const seen = new Set<string>();
+        const combined = [...leadContacts, ...adminContacts.map((m) => ({ name: m.name, phone: m.phone }))];
+        for (const c of combined) {
+          if (c.phone && !seen.has(c.name ?? "")) {
+            seen.add(c.name ?? "");
+            contactLines.push(`${c.name ?? "Team Member"} - ${c.phone}`);
+          }
+        }
+      }
+    } catch { /* ignore */ }
+
     const draft = [
       `Hi ${venueLink.venuePartner.name} Team,`,
       "",
@@ -1743,6 +1768,7 @@ export default function EventDetailPage() {
       "",
       "More about us:",
       meetupWebsite || "<Website link>",
+      "",
       "Event Details",
       "",
       `Event Name: ${event.title}`,
@@ -1762,6 +1788,9 @@ export default function EventDetailPage() {
       "Warm regards,",
       senderName,
       signaturePrimary,
+      ...(contactLines.length > 0
+        ? ["", "If you have any doubts, please feel free to contact us:", ...contactLines]
+        : []),
     ].join("\n");
 
     setVenueRequestSubject(`Venue request: ${event.title} by ${emailMeetupName}`);


### PR DESCRIPTION
## Summary

- **Contact section is now editable** — event leads and admins with phone numbers are pre-populated in the message textarea when composing a venue request, so they can be edited or removed before sending
- **Blank line fix** — added missing blank line between the website link and "Event Details" section in the draft
- **Logo switched to `logo_dark`** in the venue request email (better for light-background email clients)
- Added `phone` to event member user select in the events API so lead phone numbers are available in the frontend

## Test plan
- [ ] Open "Compose Venue Request" on an event — confirm contact lines appear at the bottom of the editable message
- [ ] Confirm contacts can be edited/removed before sending
- [ ] Confirm blank line appears between website link and Event Details
- [ ] Confirm sent email uses the dark logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)