### PR TITLE
feat: allow event creators to send venue request emails

### DIFF
--- a/src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
+++ b/src/app/api/events/[id]/venues/[linkId]/request-email/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getAuthSession } from "@/lib/auth-helpers";
-import { canUserAccessEvent, hasMinimumRole } from "@/lib/permissions";
+import { hasMinimumRole } from "@/lib/permissions";
 import { sendEmail } from "@/lib/email";
 import { logAudit } from "@/lib/audit";
 import type { GlobalRole } from "@/generated/prisma/enums";
@@ -65,16 +65,25 @@ export async function POST(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const userRole = session.user.globalRole as GlobalRole;
-  if (!hasMinimumRole(userRole, "ADMIN")) {
-    return NextResponse.json(
-      { error: "Forbidden: ADMIN or SUPER_ADMIN required" },
-      { status: 403 }
-    );
+  // First, fetch the venue link and event to check permissions
+  const link = await prisma.eventVenuePartner.findUnique({
+    where: { id: linkId },
+    include: {
+      event: { select: { id: true, title: true, createdById: true } },
+      venuePartner: { select: { name: true, email: true } },
+    },
+  });
+
+  if (!link || link.eventId !== eventId) {
+    return NextResponse.json({ error: "Venue link not found" }, { status: 404 });
   }
 
-  const canEdit = await canUserAccessEvent(session.user.id, eventId, "update");
-  if (!canEdit) {
+  // Permission check: Allow only event creator or admins
+  const isEventCreator = link.event.createdById === session.user.id;
+  const userRole = session.user.globalRole as GlobalRole;
+  const isAdmin = hasMinimumRole(userRole, "ADMIN");
+
+  if (!isEventCreator && !isAdmin) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
@@ -95,18 +104,6 @@ export async function POST(
       { error: `Invalid CC email: ${invalidCc}` },
       { status: 400 }
     );
-  }
-
-  const link = await prisma.eventVenuePartner.findUnique({
-    where: { id: linkId },
-    include: {
-      event: { select: { id: true, title: true } },
-      venuePartner: { select: { name: true, email: true } },
-    },
-  });
-
-  if (!link || link.eventId !== eventId) {
-    return NextResponse.json({ error: "Venue link not found" }, { status: 404 });
   }
 
   if (!link.venuePartner.email) {

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -1548,6 +1548,10 @@ export default function EventDetailPage() {
   // Only: 1) Super Admin (any event), or 2) Event creator if they are Admin/Super Admin
   const canDelete = event && (isSuperAdmin || (event.createdBy.id === session?.user?.id && (isAdmin || isSuperAdmin)));
 
+  // Check if user can send venue request emails
+  // Only: 1) Admin/Super Admin, or 2) Event creator
+  const canSendVenueRequest = event ? (isAdmin || event.createdBy.id === session?.user?.id) : false;
+
   const updateTask = async (
     checklistId: string,
     taskId: string,
@@ -2378,7 +2382,7 @@ export default function EventDetailPage() {
                 );
               }}
               canConfirmVenue={isAdmin}
-              canSendVenueRequest={isAdmin}
+              canSendVenueRequest={canSendVenueRequest}
               onUnlink={unlinkVenuePartner}
               onOpenVenueRequest={openVenueRequestComposer}
             />


### PR DESCRIPTION
## Changes
- Update venue request email API to allow event creators in addition to admins
- Add canSendVenueRequest permission check in frontend
- Event creators can now compose and send venue request emails for their own events
- Maintains existing admin access while extending to event ownership

## Permissions Logic
- Event creator: ✅ Can send venue emails for their events
- Admin/Super Admin: ✅ Can send venue emails for any event
- Other members: ❌ Cannot send venue emails

## Files Changed
- `src/app/api/events/[id]/venues/[linkId]/request-email/route.ts` - Updated permission check
- `src/app/events/[id]/page.tsx` - Added canSendVenueRequest variable and UI permission